### PR TITLE
Base dir

### DIFF
--- a/hpc_plugin/tasks.py
+++ b/hpc_plugin/tasks.py
@@ -24,7 +24,11 @@ from workload_managers.workload_manager import WorkloadManager
 
 
 @operation
-def prepare_hpc(config, base_dir, simulate, **kwargs):  # pylint: disable=W0613
+def prepare_hpc(config,
+                base_dir,
+                workdir_prefix,
+                simulate,
+                **kwargs):  # pylint: disable=W0613
     """ Tries to connect to a login node """
     ctx.logger.info('Connecting to login node..')
     if not simulate:
@@ -44,7 +48,11 @@ def prepare_hpc(config, base_dir, simulate, **kwargs):  # pylint: disable=W0613
 
         ctx.instance.runtime_properties['login'] = exit_code is 0
 
-        workdir = wm.create_new_workdir(client, base_dir, ctx.blueprint.id)
+        prefix = workdir_prefix
+        if workdir_prefix is "":
+            prefix = ctx.blueprint.id
+
+        workdir = wm.create_new_workdir(client, base_dir, prefix)
         if workdir is None:
             raise NonRecoverableError(
                 "failed to create the working directory, base dir: " +

--- a/hpc_plugin/tasks.py
+++ b/hpc_plugin/tasks.py
@@ -24,7 +24,7 @@ from workload_managers.workload_manager import WorkloadManager
 
 
 @operation
-def prepare_hpc(config, simulate, **kwargs):  # pylint: disable=W0613
+def prepare_hpc(config, base_dir, simulate, **kwargs):  # pylint: disable=W0613
     """ Tries to connect to a login node """
     ctx.logger.info('Connecting to login node..')
     if not simulate:
@@ -44,7 +44,11 @@ def prepare_hpc(config, simulate, **kwargs):  # pylint: disable=W0613
 
         ctx.instance.runtime_properties['login'] = exit_code is 0
 
-        workdir = wm.create_new_workdir(client, ctx.blueprint.id)
+        workdir = wm.create_new_workdir(client, base_dir, ctx.blueprint.id)
+        if workdir is None:
+            raise NonRecoverableError(
+                "failed to create the working directory, base dir: " +
+                base_dir)
         ctx.instance.runtime_properties['workdir'] = workdir
         ctx.logger.info('..HPC ready')
     else:

--- a/hpc_plugin/tasks.py
+++ b/hpc_plugin/tasks.py
@@ -50,7 +50,7 @@ def prepare_hpc(config, base_dir, simulate, **kwargs):  # pylint: disable=W0613
                 "failed to create the working directory, base dir: " +
                 base_dir)
         ctx.instance.runtime_properties['workdir'] = workdir
-        ctx.logger.info('..HPC ready')
+        ctx.logger.info('..HPC ready on ' + workdir)
     else:
         ctx.instance.runtime_properties['login'] = True
         ctx.instance.runtime_properties['workdir'] = "simulation"

--- a/hpc_plugin/tests/blueprint/blueprint_four.yaml
+++ b/hpc_plugin/tests/blueprint/blueprint_four.yaml
@@ -52,6 +52,7 @@ node_templates:
             config: { get_input: mso4sc_hpc_primary }
             external_monitor_entrypoint: { get_input: monitor_entrypoint }
             job_prefix: { get_input: job_prefix }
+            workdir_prefix: "four"
             skip_cleanup: True
             simulate: True  # COMMENT to test against a real HPC
     

--- a/hpc_plugin/tests/blueprint/blueprint_single_sbatch.yaml
+++ b/hpc_plugin/tests/blueprint/blueprint_single_sbatch.yaml
@@ -52,6 +52,7 @@ node_templates:
             config: { get_input: mso4sc_hpc_primary }
             external_monitor_entrypoint: { get_input: monitor_entrypoint }
             job_prefix: { get_input: job_prefix }
+            workdir_prefix: "single_srun"
             skip_cleanup: True
             simulate: True  # COMMENT to test against a real HPC
 

--- a/hpc_plugin/tests/blueprint/blueprint_single_singularity.yaml
+++ b/hpc_plugin/tests/blueprint/blueprint_single_singularity.yaml
@@ -52,6 +52,7 @@ node_templates:
             config: { get_input: mso4sc_hpc_primary }
             external_monitor_entrypoint: { get_input: monitor_entrypoint }
             job_prefix: { get_input: job_prefix }
+            workdir_prefix: "single_singularity"
             skip_cleanup: True
             simulate: True  # COMMENT to test against a real HPC
 

--- a/hpc_plugin/tests/blueprint/blueprint_single_srun.yaml
+++ b/hpc_plugin/tests/blueprint/blueprint_single_srun.yaml
@@ -52,8 +52,9 @@ node_templates:
             config: { get_input: mso4sc_hpc_primary }
             external_monitor_entrypoint: { get_input: monitor_entrypoint }
             job_prefix: { get_input: job_prefix }
+            workdir_prefix: "single_srun"
             skip_cleanup: True
-            simulate: True  # COMMENT to test against a real HPC
+#            simulate: True  # COMMENT to test against a real HPC
 
     single_job:
         type: hpc.nodes.job

--- a/hpc_plugin/tests/blueprint/hpc_plugin/test_plugin.yaml
+++ b/hpc_plugin/tests/blueprint/hpc_plugin/test_plugin.yaml
@@ -49,6 +49,10 @@ node_types:
                 description: Job name prefix for this HPC
                 default: "cfyhpc"
                 type: string
+            base_dir:
+                description: Root directory of all executions
+                default: "$HOME"
+                type: string
             simulate:
                 description: Set to true to simulate job without sending it
                 type: boolean
@@ -67,6 +71,8 @@ node_types:
                     inputs:
                         config:
                             default: { get_property: [SELF, config] }
+                        base_dir:
+                            default: { get_property: [SELF, base_dir] }
                         simulate:
                             default: { get_property: [SELF, simulate] }
                 stop:

--- a/hpc_plugin/tests/blueprint/hpc_plugin/test_plugin.yaml
+++ b/hpc_plugin/tests/blueprint/hpc_plugin/test_plugin.yaml
@@ -53,6 +53,10 @@ node_types:
                 description: Root directory of all executions
                 default: "$HOME"
                 type: string
+            workdir_prefix:
+                description: Prefix of the working directory instead of blueprint name
+                default: ""
+                type: string
             simulate:
                 description: Set to true to simulate job without sending it
                 type: boolean
@@ -73,6 +77,8 @@ node_types:
                             default: { get_property: [SELF, config] }
                         base_dir:
                             default: { get_property: [SELF, base_dir] }
+                        workdir_prefix:
+                            default: { get_property: [SELF, workdir_prefix] }
                         simulate:
                             default: { get_property: [SELF, simulate] }
                 stop:

--- a/hpc_plugin/workload_managers/workload_manager.py
+++ b/hpc_plugin/workload_managers/workload_manager.py
@@ -149,9 +149,10 @@ class WorkloadManager(object):
     def create_new_workdir(self, ssh_client, base_dir, base_name):
         workdir = self._get_time_name(base_name)
 
-        # we are sure that the workdir does not exists
-        while self._exists_path(ssh_client, workdir):
-            workdir = self._get_time_name(base_name)
+        # we make sure that the workdir does not exists
+        base_name = workdir
+        while self._exists_path(ssh_client, base_dir + "/" + workdir):
+            workdir = self._get_random_name(base_name)
 
         full_path = base_dir + "/" + workdir
         if self._execute_shell_command(

--- a/hpc_plugin/workload_managers/workload_manager.py
+++ b/hpc_plugin/workload_managers/workload_manager.py
@@ -146,17 +146,20 @@ class WorkloadManager(object):
                                            call,
                                            workdir=workdir)
 
-    def create_new_workdir(self, ssh_client, base_name):
+    def create_new_workdir(self, ssh_client, base_dir, base_name):
         workdir = self._get_time_name(base_name)
 
         # we are sure that the workdir does not exists
         while self._exists_path(ssh_client, workdir):
             workdir = self._get_time_name(base_name)
 
-        self._execute_shell_command(ssh_client,
-                                    "mkdir -p " + workdir)
-
-        return workdir
+        full_path = base_dir + "/" + workdir
+        if self._execute_shell_command(
+                ssh_client,
+                "mkdir -p " + base_dir + "/" + workdir):
+            return full_path
+        else:
+            return None
 
     def _build_container_script(self,
                                 name,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -42,6 +42,10 @@ node_types:
                 description: Job name prefix for this HPC
                 default: "cfyhpc"
                 type: string
+            base_dir:
+                description: Root directory of all executions
+                default: "$HOME"
+                type: string
             simulate:
                 description: Set to true to simulate job without sending it
                 type: boolean
@@ -60,6 +64,8 @@ node_types:
                     inputs:
                         config:
                             default: { get_property: [SELF, config] }
+                        base_dir:
+                            default: { get_property: [SELF, base_dir] }
                         simulate:
                             default: { get_property: [SELF, simulate] }
                 stop:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -46,6 +46,10 @@ node_types:
                 description: Root directory of all executions
                 default: "$HOME"
                 type: string
+            workdir_prefix:
+                description: Prefix of the working directory instead of blueprint name
+                default: ""
+                type: string
             simulate:
                 description: Set to true to simulate job without sending it
                 type: boolean
@@ -66,6 +70,8 @@ node_types:
                             default: { get_property: [SELF, config] }
                         base_dir:
                             default: { get_property: [SELF, base_dir] }
+                        workdir_prefix:
+                            default: { get_property: [SELF, workdir_prefix] }
                         simulate:
                             default: { get_property: [SELF, simulate] }
                 stop:


### PR DESCRIPTION
- Two new properties at hpc.nodes.Compute template (infrastructure):
`base_dir` to set the root folder.
`workdir_prefix` to set the first name of the working directory something different than the blueprint name.

- Improvements on workding directory uniqness

- $CURRENT_WORKDIR now holds the full path

Closes #14 