### PR TITLE
Removed dependency of an external monitor

### DIFF
--- a/hpc_plugin/monitors.py
+++ b/hpc_plugin/monitors.py
@@ -58,11 +58,6 @@ def get_states(monitor_jobs, logger):
                                                settings['names'],
                                                logger)
                 client.close_connection()
-                if not partial_states:
-                    partial_states = _no_states(host,
-                                                settings['type'],
-                                                settings['names'],
-                                                logger)
             else:
                 partial_states = _no_states(host,
                                             settings['type'],

--- a/hpc_plugin/monitors.py
+++ b/hpc_plugin/monitors.py
@@ -36,21 +36,25 @@ JOBSTATES = [
 ]
 
 
-def get_states(url_instances_map, url_mtype_map, url_host_map):
+def get_states(monitor_jobs):
     """ Retrieves the status of every job asking to the monitors"""
     states = {}
 
-    for url, names in url_instances_map.iteritems():
-        if url_mtype_map[url] == "PROMETHEUS":
-            _get_prometheus(url, names, url_host_map[url], states)
+    for host, settings in monitor_jobs.iteritems():
+        if settings['type'] == "PROMETHEUS":
+            _get_prometheus(host,
+                            settings['config'],
+                            settings['names'],
+                            states)
         else:
-            print "ERROR: Monitor of type " + url_mtype_map[url] + \
+            print "ERROR: Monitor of type " + settings['type'] + \
                 "not suppported."
 
     return states
 
 
-def _get_prometheus(url, names, host, states):
+def _get_prometheus(host, config, names, states):
+    url = config['url']
     if len(names) == 1:
         query = (url + '/api/v1/query?query=job_status'
                  '%7Bjob%3D%22' + host +

--- a/hpc_plugin/monitors.py
+++ b/hpc_plugin/monitors.py
@@ -36,7 +36,7 @@ JOBSTATES = [
 ]
 
 
-def get_states(monitor_jobs):
+def get_states(monitor_jobs, logger):
     """ Retrieves the status of every job asking to the monitors"""
     states = {}
 
@@ -47,8 +47,15 @@ def get_states(monitor_jobs):
                             settings['names'],
                             states)
         else:
-            print "ERROR: Monitor of type " + settings['type'] + \
-                "not suppported."
+            logger.error("Monitor of type " +
+                         settings['type'] +
+                         " not suppported. " +
+                         "Jobs [" +
+                         ','.join(settings['names']) +
+                         "] on host '" + host
+                         + "' will be considered FAILED.")
+            for name in settings['names']:
+                states[name] = 'FAILED'
 
     return states
 

--- a/hpc_plugin/monitors.py
+++ b/hpc_plugin/monitors.py
@@ -16,6 +16,7 @@
 """ Holds the functions that requests monitor information """
 
 import requests
+from ssh import SshClient
 from workload_managers.workload_manager import WorkloadManager
 
 JOBSTATES = [
@@ -49,9 +50,14 @@ def get_states(monitor_jobs, logger):
         else:  # internal
             wm = WorkloadManager.factory(settings['type'])
             if wm:
-                partial_states = wm.get_states(settings['config'],
+                credentials = settings['config']
+                client = SshClient(credentials['host'],
+                                   credentials['user'],
+                                   credentials['password'])
+                partial_states = wm.get_states(client,
                                                settings['names'],
                                                logger)
+                client.close_connection()
                 if not partial_states:
                     partial_states = _no_states(host,
                                                 settings['type'],

--- a/hpc_plugin/tasks.py
+++ b/hpc_plugin/tasks.py
@@ -58,6 +58,7 @@ def prepare_hpc(config,
             prefix = ctx.blueprint.id
 
         workdir = wm.create_new_workdir(client, base_dir, prefix)
+        client.close_connection()
         if workdir is None:
             raise NonRecoverableError(
                 "failed to create the working directory, base dir: " +
@@ -93,6 +94,7 @@ def cleanup_hpc(config, skip, simulate, **kwargs):  # pylint: disable=W0613
         _, exit_code = wm._execute_shell_command(client,
                                                  'rm -r ' + workdir,
                                                  wait_result=True)
+        client.close_connection()
         ctx.logger.info('..all clean.')
     else:
         ctx.logger.warning('HPC clean up simulated.')

--- a/hpc_plugin/tasks.py
+++ b/hpc_plugin/tasks.py
@@ -34,6 +34,11 @@ def prepare_hpc(config,
     if not simulate:
         wm_type = config['workload_manager']
         wm = WorkloadManager.factory(wm_type)
+        if not wm:
+            raise NonRecoverableError(
+                "Workload Manager '" +
+                wm_type +
+                "' not supported.")
         credentials = config['credentials']
         client = SshClient(credentials['host'],
                            credentials['user'],
@@ -76,6 +81,11 @@ def cleanup_hpc(config, skip, simulate, **kwargs):  # pylint: disable=W0613
         workdir = ctx.instance.runtime_properties['workdir']
         wm_type = config['workload_manager']
         wm = WorkloadManager.factory(wm_type)
+        if not wm:
+            raise NonRecoverableError(
+                "Workload Manager '" +
+                wm_type +
+                "' not supported.")
         credentials = config['credentials']
         client = SshClient(credentials['host'],
                            credentials['user'],
@@ -288,8 +298,12 @@ def deploy_job(script,
                skip_cleanup):  # pylint: disable=W0613
     """ Exec a eployment job script that receives SSH credentials as input """
 
-    # TODO(emepetres): manage errors
     wm = WorkloadManager.factory(wm_type)
+    if not wm:
+        raise NonRecoverableError(
+            "Workload Manager '" +
+            wm_type +
+            "' not supported.")
 
     # Execute the script and manage the output
     client = SshClient(credentials['host'],
@@ -340,8 +354,12 @@ def send_job(job_options, **kwargs):  # pylint: disable=W0613
                            credentials['user'],
                            credentials['password'])
 
-        # TODO(emepetres): manage errors
         wm = WorkloadManager.factory(wm_type)
+        if not wm:
+            raise NonRecoverableError(
+                "Workload Manager '" +
+                wm_type +
+                "' not supported.")
         is_submitted = wm.submit_job(client,
                                      name,
                                      job_options,
@@ -385,6 +403,11 @@ def cleanup_job(job_options, skip, **kwargs):  # pylint: disable=W0613
 
         # TODO(emepetres): manage errors
         wm = WorkloadManager.factory(wm_type)
+        if not wm:
+            raise NonRecoverableError(
+                "Workload Manager '" +
+                wm_type +
+                "' not supported.")
         is_clean = wm.clean_job_aux_files(client,
                                           name,
                                           job_options,
@@ -423,6 +446,11 @@ def stop_job(job_options, **kwargs):  # pylint: disable=W0613
 
         # TODO(emepetres): manage errors
         wm = WorkloadManager.factory(wm_type)
+        if not wm:
+            raise NonRecoverableError(
+                "Workload Manager '" +
+                wm_type +
+                "' not supported.")
         is_stopped = wm.stop_job(client,
                                  name,
                                  job_options,

--- a/hpc_plugin/tasks.py
+++ b/hpc_plugin/tasks.py
@@ -102,11 +102,11 @@ def preconfigure_job(config,
 
     ctx.source.instance.runtime_properties['credentials'] = \
         config['credentials']
-    ctx.source.instance.runtime_properties['monitor_entrypoint'] = \
+    ctx.source.instance.runtime_properties['external_monitor_entrypoint'] = \
         external_monitor_entrypoint
-    ctx.source.instance.runtime_properties['monitor_port'] = \
+    ctx.source.instance.runtime_properties['external_monitor_port'] = \
         external_monitor_port
-    ctx.source.instance.runtime_properties['monitor_type'] = \
+    ctx.source.instance.runtime_properties['external_monitor_type'] = \
         external_monitor_type
     ctx.source.instance.runtime_properties['monitor_orchestrator_port'] = \
         external_monitor_orchestrator_port

--- a/hpc_plugin/tests/blueprint/blueprint_four.yaml
+++ b/hpc_plugin/tests/blueprint/blueprint_four.yaml
@@ -55,7 +55,7 @@ node_templates:
             base_dir: "$LUSTRE"
             workdir_prefix: "four"
             skip_cleanup: True
-            simulate: True  # COMMENT to test against a real HPC
+#            simulate: True  # COMMENT to test against a real HPC
     
     first_job:
         type: hpc.nodes.job

--- a/hpc_plugin/tests/blueprint/blueprint_four.yaml
+++ b/hpc_plugin/tests/blueprint/blueprint_four.yaml
@@ -55,7 +55,7 @@ node_templates:
             base_dir: "$LUSTRE"
             workdir_prefix: "four"
             skip_cleanup: True
-#            simulate: True  # COMMENT to test against a real HPC
+            simulate: True  # COMMENT to test against a real HPC
     
     first_job:
         type: hpc.nodes.job

--- a/hpc_plugin/tests/workflow_tests.py
+++ b/hpc_plugin/tests/workflow_tests.py
@@ -111,7 +111,7 @@ class TestPlugin(unittest.TestCase):
                                        'hpc_plugin'),
                                       (os.path.join('blueprint', 'scripts',
                                                     'bootstrap_' +
-                                                    'sbatch_example.sh'),
+                                                    'sbatch_scale_example.sh'),
                                        'scripts'),
                                       (os.path.join('blueprint', 'scripts',
                                                     'revert_' +

--- a/hpc_plugin/workflows.py
+++ b/hpc_plugin/workflows.py
@@ -368,7 +368,7 @@ class Monitor(object):
         self.timestamp = time.time()
 
         # then look for the status of the instances through its name
-        states = monitors.get_states(monitor_jobs)
+        states = monitors.get_states(monitor_jobs, self.logger)
 
         # finally set job status
         for inst_name, state in states.iteritems():

--- a/hpc_plugin/workflows.py
+++ b/hpc_plugin/workflows.py
@@ -21,6 +21,8 @@ from cloudify.decorators import workflow
 from cloudify.workflows import ctx, api, tasks
 from hpc_plugin import monitors
 
+MONITOR_PERIOD = 15
+
 
 BOOTFAIL = 0
 CANCELLED = 1
@@ -324,7 +326,7 @@ def build_graph(nodes):
 
 
 class Monitor(object):
-    """Monitor the instances talking with prometheus"""
+    """Monitor the instances"""
 
     def __init__(self, job_instances_map, logger):
         self.job_ids = {}
@@ -359,7 +361,7 @@ class Monitor(object):
             return
 
         # We wait to not sature the monitor
-        seconds_to_wait = 15 - (time.time() - self.timestamp)
+        seconds_to_wait = MONITOR_PERIOD - (time.time() - self.timestamp)
         if seconds_to_wait > 0:
             sys.stdout.flush()  # necessary to output work properly with sleep
             time.sleep(seconds_to_wait)

--- a/hpc_plugin/workload_managers/slurm.py
+++ b/hpc_plugin/workload_managers/slurm.py
@@ -152,7 +152,6 @@ class Slurm(WorkloadManager):
                 "SCALE_MAX=" + str(scale_max) + "\\n\\n/' " +\
                 job_settings['command'].split()[0]  # get only the file
             response['scale_env_mapping_call'] = scale_env_mapping_call
-            print scale_env_mapping_call
 
         # add executable and arguments
         slurm_call += ' ' + job_settings['command']
@@ -171,15 +170,8 @@ class Slurm(WorkloadManager):
 
 # Monitor
     def get_states(self, ssh_client, names, logger):
-        # TODO(emepetres) set first day of consulting
+        # TODO(emepetres) set start time of consulting
         # (sacct only check current day)
-        # INFO for scale changes
-        # sacct -n -o jobname%32,jobid -X -P --name=mso_zse43j
-        # mso_zse43j|930223_1
-        # mso_zse43j|930223_0
-        # sacct -n -o jobname%32,jobIDRaw -X -P --name=mso_zse43j
-        # mso_zse43j|930223
-        # mso_zse43j|930226
         call = "sacct -n -o JobName,State -X -P --name=" + ','.join(names)
         output, exit_code = self._execute_shell_command(ssh_client,
                                                         call,

--- a/hpc_plugin/workload_managers/workload_manager.py
+++ b/hpc_plugin/workload_managers/workload_manager.py
@@ -193,8 +193,7 @@ class WorkloadManager(object):
         @rtype dict
         @return a dictionary of job names and its states
         """
-        logger.error("'get_states' not implemented.")
-        return {}
+        raise NotImplementedError("'get_states' not implemented.")
 
     def _build_container_script(self,
                                 name,
@@ -210,8 +209,7 @@ class WorkloadManager(object):
         @rtype string
         @return string to with the sbatch script. None if an error arise.
         """
-        logger.error("'_build_container_script' not implemented.")
-        return None
+        raise NotImplementedError("'_build_container_script' not implemented.")
 
     def _build_job_submission_call(self,
                                    name,
@@ -228,7 +226,8 @@ class WorkloadManager(object):
         @return string to call slurm with its parameters.
             None if an error arise.
         """
-        return {'error': "'_build_job_submission_call' not implemented."}
+        raise NotImplementedError(
+            "'_build_job_submission_call' not implemented.")
 
     def _build_job_cancellation_call(self,
                                      name,
@@ -245,8 +244,8 @@ class WorkloadManager(object):
         @return string to call slurm with its parameters.
             None if an error arise.
         """
-        logger.error("'_build_job_cancellation_call' not implemented.")
-        return None
+        raise NotImplementedError(
+            "'_build_job_cancellation_call' not implemented.")
 
     def _checkSshClient(self,
                         ssh_client,

--- a/hpc_plugin/workload_managers/workload_manager.py
+++ b/hpc_plugin/workload_managers/workload_manager.py
@@ -182,7 +182,7 @@ class WorkloadManager(object):
         else:
             return None
 
-    def get_states(self, credentials, names, logger):
+    def get_states(self, ssh_client, names, logger):
         """
         Get the states of the jobs names
 
@@ -194,7 +194,7 @@ class WorkloadManager(object):
         @return a dictionary of job names and its states
         """
         logger.error("'get_states' not implemented.")
-        return None
+        return {}
 
     def _build_container_script(self,
                                 name,

--- a/hpc_plugin/workload_managers/workload_manager.py
+++ b/hpc_plugin/workload_managers/workload_manager.py
@@ -10,8 +10,8 @@ class WorkloadManager(object):
         if workload_manager == "SLURM":
             from slurm import Slurm
             return Slurm()
-        assert 0, "Bad workload manager creation: " +\
-            workload_manager
+        else:
+            return None
     factory = staticmethod(factory)
 
     def submit_job(self,
@@ -181,6 +181,20 @@ class WorkloadManager(object):
             return full_path
         else:
             return None
+
+    def get_states(self, credentials, names, logger):
+        """
+        Get the states of the jobs names
+
+        @type credentials: dictionary
+        @param credentials: dictionary with the HPC SSH credentials
+        @type names: list
+        @param names: list of the job names to retrieve their states
+        @rtype dict
+        @return a dictionary of job names and its states
+        """
+        logger.error("'get_states' not implemented.")
+        return None
 
     def _build_container_script(self,
                                 name,


### PR DESCRIPTION
The orchestrator can now perform basic monitoring to not depend on an external monitor to work.

Just not setting the property `external_monitor_entrypoint` or leaving it empty `""` will trigger the "internal monitor" mechanism.

Only Slurm machines support for now.